### PR TITLE
Add parametrized benchmark for using sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,6 +116,15 @@ dependencies = [
 
 [[package]]
 name = "ansi_term"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
@@ -403,6 +412,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "065374052e7df7ee4047b1160cca5e1467a12351a40b3da123c870ba0b8eda2a"
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -657,6 +677,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12f8e7987cbd042a63249497f41aed09f8e65add917ea6566effbc56578d6801"
 dependencies = [
  "generic-array 0.14.4",
+]
+
+[[package]]
+name = "clap"
+version = "2.33.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+dependencies = [
+ "ansi_term 0.11.0",
+ "atty",
+ "bitflags",
+ "strsim",
+ "textwrap",
+ "unicode-width",
+ "vec_map",
 ]
 
 [[package]]
@@ -1417,6 +1452,8 @@ dependencies = [
  "parking_lot",
  "prometheus",
  "rand 0.8.3",
+ "structopt",
+ "tempdir",
  "thiserror",
  "tide",
  "tracing",
@@ -3006,6 +3043,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "structopt"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5277acd7ee46e63e5168a80734c9f6ee81b1367a7d8772a2d765df2a3705d28c"
+dependencies = [
+ "clap",
+ "lazy_static",
+ "structopt-derive",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ba9cdfda491b814720b6b06e0cac513d922fc407582032e8706e9f137976f90"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "subtle"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3047,6 +3114,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempdir"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
+dependencies = [
+ "rand 0.4.6",
+ "remove_dir_all",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3058,6 +3135,15 @@ dependencies = [
  "redox_syscall",
  "remove_dir_all",
  "winapi",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -3243,7 +3329,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ab8966ac3ca27126141f7999361cc97dd6fb4b71da04c02044fa9045d98bb96"
 dependencies = [
- "ansi_term",
+ "ansi_term 0.12.1",
  "chrono",
  "lazy_static",
  "matchers",
@@ -3300,6 +3386,12 @@ name = "unicode-segmentation"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
 
 [[package]]
 name = "unicode-xid"
@@ -3375,6 +3467,12 @@ name = "vec-arena"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eafc1b9b2dfc6f5529177b62cf806484db55b32dc7c9658a118e11bbeb33061d"
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,8 @@ libipld = { version = "0.11.0", default-features = false, features = ["dag-cbor"
 libp2p-bitswap = { version = "0.14.1", default-features = false, features = ["compat"] }
 multihash = { version = "0.13.2", default-features = false, features = ["blake3"] }
 rand = "0.8.3"
+structopt = "0.3.21"
+tempdir = "0.3.7"
 tracing-subscriber = "0.2.16"
 
 [profile.release]

--- a/examples/bitswap_sync_bench.rs
+++ b/examples/bitswap_sync_bench.rs
@@ -1,0 +1,195 @@
+use anyhow::Result;
+use futures::prelude::*;
+use ipfs_embed::{Config, DefaultParams, Ipfs, NetworkConfig, StorageConfig};
+use libipld::{alias, cbor::DagCborCodec, multihash::Code, Block, Cid, DagCbor};
+use rand::RngCore;
+use std::time::{Instant, Duration};
+use std::path::PathBuf;
+use structopt::StructOpt;
+use tempdir::TempDir;
+
+#[derive(Debug, StructOpt)]
+#[structopt(name = "bench")]
+struct Opt {
+    #[structopt(long, default_value = "1")]
+    n_providers: usize,
+
+    #[structopt(long, default_value = "2")]
+    n_nodes: usize,
+
+    #[structopt(long, default_value = "0")]
+    n_spam: usize,
+
+    #[structopt(long)]
+    in_memory: bool,
+}
+
+#[derive(Debug, DagCbor)]
+pub struct Node {
+    pub links: Vec<Cid>,
+    pub depth: u64,
+    pub payload: Box<[u8]>,
+}
+
+fn create_block(links: Vec<Cid>, depth: u64) -> Result<Block<DefaultParams>> {
+    let payload = if links.is_empty() {
+        let mut payload = [0u8; 1024 * 16];
+        let mut rng = rand::thread_rng();
+        rng.fill_bytes(&mut payload);
+        payload.to_vec().into_boxed_slice()
+    } else {
+        let mut payload = [0u8; 512];
+        let mut rng = rand::thread_rng();
+        rng.fill_bytes(&mut payload);
+        payload.to_vec().into_boxed_slice()
+    };
+    let node = Node {
+        links,
+        depth,
+        payload,
+    };
+    Block::encode(DagCborCodec, Code::Blake3_256, &node)
+}
+
+fn build_tree_0(width: u64, depth: u64, blocks: &mut Vec<Block<DefaultParams>>) -> Result<Cid> {
+    let links = if depth == 0 {
+        vec![]
+    } else {
+        let mut links = Vec::with_capacity(width as usize);
+        for _ in 0..width {
+            let cid = build_tree_0(width, depth - 1, blocks)?;
+            links.push(cid);
+        }
+        links
+    };
+    let block = create_block(links, depth)?;
+    let cid = *block.cid();
+    blocks.push(block);
+    Ok(cid)
+}
+
+pub fn build_tree(width: u64, depth: u64) -> Result<(Cid, Vec<Block<DefaultParams>>)> {
+    let mut blocks = vec![];
+    let cid = build_tree_0(width, depth, &mut blocks)?;
+    Ok((cid, blocks))
+}
+
+fn tracing_try_init() {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .try_init()
+        .ok();
+}
+
+async fn create_store(path: Option<PathBuf>, enable_mdns: bool) -> Result<Ipfs<DefaultParams>> {
+    let sweep_interval = Duration::from_millis(10000);
+    let storage = StorageConfig::new(path, 10, sweep_interval);
+
+    let mut network = NetworkConfig::new();
+    network.enable_mdns = enable_mdns;
+    network.allow_non_globals_in_dht = true;
+    // network.enable_kad = false;
+    network.bitswap.receive_limit = std::num::NonZeroU16::new(u16::MAX).unwrap();
+
+    let ipfs = Ipfs::new(Config { storage, network }).await?;
+    ipfs.listen_on("/ip4/127.0.0.1/tcp/0".parse()?).await?;
+    Ok(ipfs)
+}
+
+/// Parametrized test for sync
+///
+/// `name` name of the test
+/// `n_nodes` total number of nodes to participate in the test. Must be >= 2
+/// `n_providers` total number of providers for the data to be synced. Must be >= 1
+/// `n_spam` number of times the test data will be repeated as passive data on all nodes
+/// `create_test_data` generator for test data
+async fn run_test(
+    name: &str,
+    n_nodes: usize,
+    n_providers: usize,
+    n_spam: usize,
+    on_disk: bool,
+    create_test_data: impl Fn() -> Result<(Cid, Vec<Block<DefaultParams>>)>,
+) -> Result<()> {
+    assert!(n_nodes >= 2);
+    assert!(n_providers >= 1);
+    assert!(n_providers < n_nodes);
+
+    let temp_dir = if on_disk {
+        Some(TempDir::new(name)?)
+    } else {
+        None
+    };
+
+    // create n_nodes nodes. They will find each other via mdns
+    let mut nodes = Vec::new();
+    for i in 0..n_nodes {
+        let path = temp_dir.as_ref().map(|dir| dir.path().join(&format!("node-{}.sqlite", i)));
+        nodes.push(create_store(path, true).await?);
+    }
+
+    // create some blocks in each node that will not participate in the sync
+    for i in 0..n_spam {
+        let alias = format!("passive-{}", i);
+        let (cid, blocks) = create_test_data()?;
+        for node in &nodes {
+            node.alias(&alias, Some(&cid))?;
+            for block in blocks.iter() {
+                let _ = node.insert(block)?.await;
+            }
+            node.flush().await?;
+        }
+    }
+
+    // create the blocks to be synced in n_providers nodes
+    let root = alias!(root);
+    let (cid, blocks) = create_test_data()?;
+    for i in 0..n_providers {
+        let node = &nodes[i];
+        node.alias(root, Some(&cid))?;
+        for block in blocks.iter() {
+            let _ = node.insert(block)?.await;
+        }
+        node.flush().await?;
+    }
+
+    // wait until all nodes are connected
+    while nodes.iter().any(|node| node.connections().len() < n_nodes -1) {
+        std::thread::sleep(Duration::from_secs(1));
+    }
+    println!("nodes fully connected");
+
+    // compute total size of data to be synced
+    let size: usize = blocks.iter().map(|block| block.data().len()).sum();
+    tracing::info!("test data built {} blocks, {} bytes", blocks.len(), size);
+
+    let target = || nodes.last().unwrap();
+
+    target().alias(root, Some(&cid))?;
+    let t0 = Instant::now();
+    let _ = target()
+        .sync(&cid)
+        .for_each(|x| async move { tracing::debug!("sync progress {:?}", x) })
+        .await;
+    target().flush().await?;
+    println!(
+        "{}, tree sync complete {} ms {} blocks {} bytes!",
+        name,
+        t0.elapsed().as_millis(),
+        blocks.len(),
+        size
+    );
+    // check that data is indeed synced
+    for block in blocks {
+        let data = target().get(block.cid())?;
+        assert_eq!(data, block);
+    }
+    Ok(())
+}
+
+#[async_std::main]
+async fn main() -> Result<()> {
+    tracing_try_init();
+    let opt = Opt::from_args();
+    run_test("2 nodes", opt.n_nodes, opt.n_providers, opt.n_spam, !opt.in_memory, || build_tree(10, 4)).await
+}


### PR DESCRIPTION
cargo run --release --example bitswap_sync_bench -- --in-memory

I think this should be useful to optimize bitswap sync for different scenarios.