### PR TITLE
Add support for different async executors (initially async-std (via `async_global_executor`) and tokio 1.x).

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,4 +110,4 @@ jobs:
       run: cargo fmt --all -- --check
 
     - name: cargo clippy
-      run: cargo clippy --workspace --examples --tests -- -D warnings
+      run: cargo clippy --workspace --examples --tests --all-features -- -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,11 +78,11 @@ jobs:
 
     - name: Build
       if: contains(matrix.platform.target, 'android') == false
-      run: cargo build --target ${{ matrix.platform.target }}
+      run: cargo build --all-features --target ${{ matrix.platform.target }}
 
     - name: Build android
       if: contains(matrix.platform.target, 'android')
-      run: cargo apk build --target ${{ matrix.platform.target }}
+      run: cargo apk build --all-features --target ${{ matrix.platform.target }}
 
     - name: Rust tests
       if: matrix.platform.cross == false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
 
     - name: Rust tests
       if: matrix.platform.cross == false
-      run: cargo test
+      run: cargo test --all-features
 
   lint-rust:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1520,10 +1520,12 @@ dependencies = [
  "multihash",
  "names",
  "parking_lot",
+ "pin-project 1.0.6",
  "prometheus",
  "rand 0.8.3",
  "thiserror",
  "tide",
+ "tokio",
  "tracing",
  "tracing-subscriber",
  "void",
@@ -2072,12 +2074,14 @@ dependencies = [
  "async-io",
  "futures",
  "futures-timer",
+ "if-addrs",
  "if-watch",
  "ipnet",
  "libc",
  "libp2p-core",
  "log 0.4.14",
  "socket2 0.4.0",
+ "tokio",
 ]
 
 [[package]]
@@ -2217,6 +2221,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "mio"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf80d3e903b34e0bd7282b218398aec54e082c840d9baf8339e0080a0c542956"
+dependencies = [
+ "libc",
+ "log 0.4.14",
+ "miow",
+ "ntapi",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "miow"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
+dependencies = [
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2383,6 +2409,15 @@ name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
+
+[[package]]
+name = "ntapi"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+dependencies = [
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "num-integer"
@@ -3640,6 +3675,18 @@ name = "tinyvec_macros"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+
+[[package]]
+name = "tokio"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83f0c8e7c0addab50b663055baf787d0af7f413a46e6e7fb9559a4e4db7137a5"
+dependencies = [
+ "autocfg",
+ "libc",
+ "mio",
+ "pin-project-lite 0.2.6",
+]
 
 [[package]]
 name = "toml"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,14 @@ description = "small embeddable ipfs implementation"
 repository = "https://github.com/ipfs-rust/ipfs-embed"
 
 [features]
-telemetry = ["tide"]
+default = ["async_global"]
+async_global = ["async-global-executor", "libp2p/tcp-async-io"]
+tokio = ["tokio-crate", "libp2p/tcp-tokio"]
+telemetry = ["tide", "async_global"]
 
 [dependencies]
 anyhow = "1.0.40"
-async-global-executor = "2.0.2"
+async-global-executor = { version = "2.0.2", optional = true }
 async-io = "1.3.1"
 async-trait = "0.1.49"
 fnv = "1.0.7"
@@ -28,9 +31,11 @@ libp2p-broadcast = "0.3.0"
 libp2p-quic = { git = "https://github.com/ipfs-rust/libp2p-quic" }
 names = "0.11.0"
 parking_lot = "0.11.1"
+pin-project = "1.0.6"
 prometheus = "0.12.0"
 thiserror = "1.0.24"
 tide = { version = "0.16.0", optional = true }
+tokio-crate = { package = "tokio", version = "1.5.0", features = ["rt"], optional = true }
 tracing = "0.1.25"
 void = "1.0.2"
 
@@ -45,7 +50,7 @@ features = [
     "mdns",
     "ping",
     #"relay",
-    "mplex", "noise", "pnet", "tcp-async-io", "yamux",
+    "mplex", "noise", "pnet", "yamux",
 ]
 
 [dev-dependencies]

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -1,0 +1,147 @@
+//! ipfs-embed supports different configuration of the used async executor to spawn its background
+//! tasks (network, garbage collection, etc.). Those can be configured with the following feature
+//! flags:
+//! * `async_global`: Uses the `async-global-executor` crate (with async-std). This is the default.
+//! * `tokio`: Uses a user provided tokio >= 1.0 runtime to spawn its background tasks.  Note, that
+//! for this to work `ipfs-embed` needs to be executed within the context of a tokio runtime.
+//! ipfs-embed won't spawn any on its own.
+
+use futures::{Future, FutureExt};
+use pin_project::pin_project;
+use std::{pin::Pin, task::Poll};
+
+#[derive(Clone)]
+pub enum Executor {
+    #[cfg(feature = "tokio")]
+    Tokio,
+    #[cfg(feature = "async_global")]
+    AsyncGlobal,
+}
+impl Executor {
+    #[allow(unreachable_code)]
+    pub fn new() -> Self {
+        #[cfg(feature = "async_global")]
+        return Self::AsyncGlobal;
+
+        #[cfg(feature = "tokio")]
+        return Self::Tokio;
+    }
+    pub fn spawn<F: Future<Output = T> + Send + 'static, T: Send + 'static>(
+        &self,
+        future: F,
+    ) -> JoinHandle<T> {
+        match self {
+            #[cfg(feature = "async_global")]
+            Self::AsyncGlobal => {
+                let task = async_global_executor::spawn(future);
+                JoinHandle::AsyncGlobal(Some(task))
+            }
+            #[cfg(feature = "tokio")]
+            Self::Tokio => {
+                let task = tokio_crate::spawn(future);
+                JoinHandle::Tokio(task)
+            }
+        }
+    }
+
+    pub fn spawn_blocking<Fun: FnOnce() -> T + Send + 'static, T: Send + 'static>(
+        &self,
+        f: Fun,
+    ) -> JoinHandle<T> {
+        match self {
+            #[cfg(feature = "async_global")]
+            Self::AsyncGlobal => {
+                let task = async_global_executor::spawn(async_global_executor::spawn_blocking(f));
+                JoinHandle::AsyncGlobal(Some(task))
+            }
+            #[cfg(feature = "tokio")]
+            Self::Tokio => {
+                let task = tokio_crate::task::spawn_blocking(f);
+                JoinHandle::Tokio(task)
+            }
+        }
+    }
+}
+
+#[pin_project(project = EnumProj)]
+pub enum JoinHandle<T> {
+    #[cfg(feature = "tokio")]
+    Tokio(tokio_crate::task::JoinHandle<T>),
+    #[cfg(feature = "async_global")]
+    AsyncGlobal(Option<async_global_executor::Task<T>>),
+}
+
+impl<T> JoinHandle<T> {
+    #[allow(unused_mut)]
+    pub fn detach(mut self) {
+        #[cfg(feature = "async_global")]
+        if let Self::AsyncGlobal(Some(t)) = self {
+            t.detach()
+        }
+    }
+}
+
+impl<T> Future for JoinHandle<T> {
+    type Output = anyhow::Result<T>;
+    fn poll(self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        match this {
+            #[cfg(feature = "tokio")]
+            EnumProj::Tokio(j) => match j.poll_unpin(cx) {
+                Poll::Ready(t) => {
+                    use anyhow::Context;
+                    Poll::Ready(t.context("tokio::task::JoinHandle Error"))
+                }
+                Poll::Pending => Poll::Pending,
+            },
+            #[cfg(feature = "async_global")]
+            EnumProj::AsyncGlobal(h) => {
+                if let Some(handle) = h {
+                    match handle.poll_unpin(cx) {
+                        Poll::Ready(r) => Poll::Ready(Ok(r)),
+                        _ => Poll::Pending,
+                    }
+                } else {
+                    Poll::Ready(Err(anyhow::anyhow!("Future detached")))
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{Config, DefaultParams, Executor, Ipfs};
+
+    #[test]
+    fn should_work_with_async_global_per_default() {
+        use futures::executor::block_on;
+        block_on(Ipfs::<DefaultParams>::new(Config::new(None, 100))).unwrap();
+    }
+
+    #[cfg(feature = "tokio")]
+    #[test]
+    #[should_panic(
+        expected = "here is no reactor running, must be called from the context of a Tokio 1.x runtime"
+    )]
+    fn should_panic_without_a_tokio_runtime() {
+        use futures::executor::block_on;
+        let _ = block_on(Ipfs::<DefaultParams>::new0(
+            Config::new(None, 100),
+            Executor::Tokio,
+        ));
+    }
+
+    #[cfg(feature = "tokio")]
+    #[test]
+    fn should_not_panic_with_a_tokio_runtime() {
+        let rt = tokio_crate::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap();
+        rt.block_on(Ipfs::<DefaultParams>::new0(
+            Config::new(None, 100),
+            Executor::Tokio,
+        ))
+        .unwrap();
+    }
+}


### PR DESCRIPTION
This lets user choose another async executor. An `Executor` struct is
added to abstract over different executors. Each spawned `Future`
returns a `JoinHandle`, with which the task can either be cancelled (by
dropping the handle), or detached. Initial support is added for
async-std (via `async_global_executor`) and tokio 1.x.

I went with this approach rather than adding an `Executor` trait,
because I think we can add support for additional async executors if the
need arises, and we can get around unnecessary allocations when spawning
futures. With this, the additional complexity is hidden in feature flags
and does not leak into the APIs, and I don't think the freedom of a
trait based approach is necessary.

Further, when the `tokio` feature is set, `tokio` is also used to
configure libp2p's TCP transport.

Closes #68