### PR TITLE
Transactional db ops

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1645,6 +1645,7 @@ dependencies = [
 [[package]]
 name = "libp2p"
 version = "0.38.0"
+source = "git+https://github.com/dvc94ch/rust-libp2p?branch=sim-open#f096d31deabe0e4eaf08ea2c1dd63ceb5574bf94"
 dependencies = [
  "atomic",
  "bytes",
@@ -1675,8 +1676,7 @@ dependencies = [
 [[package]]
 name = "libp2p-bitswap"
 version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "873b525ea4700128f1531be92859e1a673e0ea476879b7b9df83a4939526cf4e"
+source = "git+https://github.com/ipfs-rust/libp2p-bitswap?branch=sim-open#2d81161634b2d4086f63987e728fd933c3e16402"
 dependencies = [
  "async-trait",
  "fnv",
@@ -1685,8 +1685,6 @@ dependencies = [
  "libipld",
  "libp2p",
  "prometheus",
- "prost",
- "prost-build",
  "thiserror",
  "tracing",
  "unsigned-varint 0.7.0",
@@ -1695,8 +1693,7 @@ dependencies = [
 [[package]]
 name = "libp2p-broadcast"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72cb0e39c68735f5b5f81e61a9b2ce99fa5ff47c2bb69208764d3548dc3d37e8"
+source = "git+https://github.com/ipfs-rust/libp2p-broadcast?branch=sim-open#2ab76909e906a7352d0cc3a3e2a8822e15f73a4e"
 dependencies = [
  "fnv",
  "futures",
@@ -1706,6 +1703,7 @@ dependencies = [
 [[package]]
 name = "libp2p-core"
 version = "0.29.0"
+source = "git+https://github.com/dvc94ch/rust-libp2p?branch=sim-open#f096d31deabe0e4eaf08ea2c1dd63ceb5574bf94"
 dependencies = [
  "asn1_der",
  "bs58",
@@ -1738,6 +1736,7 @@ dependencies = [
 [[package]]
 name = "libp2p-dns"
 version = "0.29.0"
+source = "git+https://github.com/dvc94ch/rust-libp2p?branch=sim-open#f096d31deabe0e4eaf08ea2c1dd63ceb5574bf94"
 dependencies = [
  "async-std-resolver",
  "futures",
@@ -1750,6 +1749,7 @@ dependencies = [
 [[package]]
 name = "libp2p-gossipsub"
 version = "0.32.0"
+source = "git+https://github.com/dvc94ch/rust-libp2p?branch=sim-open#f096d31deabe0e4eaf08ea2c1dd63ceb5574bf94"
 dependencies = [
  "asynchronous-codec",
  "base64 0.13.0",
@@ -1774,6 +1774,7 @@ dependencies = [
 [[package]]
 name = "libp2p-identify"
 version = "0.30.0"
+source = "git+https://github.com/dvc94ch/rust-libp2p?branch=sim-open#f096d31deabe0e4eaf08ea2c1dd63ceb5574bf94"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -1788,6 +1789,7 @@ dependencies = [
 [[package]]
 name = "libp2p-kad"
 version = "0.31.0"
+source = "git+https://github.com/dvc94ch/rust-libp2p?branch=sim-open#f096d31deabe0e4eaf08ea2c1dd63ceb5574bf94"
 dependencies = [
  "arrayvec",
  "asynchronous-codec",
@@ -1812,6 +1814,7 @@ dependencies = [
 [[package]]
 name = "libp2p-mdns"
 version = "0.31.0"
+source = "git+https://github.com/dvc94ch/rust-libp2p?branch=sim-open#f096d31deabe0e4eaf08ea2c1dd63ceb5574bf94"
 dependencies = [
  "async-io",
  "data-encoding",
@@ -1831,6 +1834,7 @@ dependencies = [
 [[package]]
 name = "libp2p-mplex"
 version = "0.29.0"
+source = "git+https://github.com/dvc94ch/rust-libp2p?branch=sim-open#f096d31deabe0e4eaf08ea2c1dd63ceb5574bf94"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -1847,6 +1851,7 @@ dependencies = [
 [[package]]
 name = "libp2p-noise"
 version = "0.32.0"
+source = "git+https://github.com/dvc94ch/rust-libp2p?branch=sim-open#f096d31deabe0e4eaf08ea2c1dd63ceb5574bf94"
 dependencies = [
  "bytes",
  "curve25519-dalek",
@@ -1867,6 +1872,7 @@ dependencies = [
 [[package]]
 name = "libp2p-ping"
 version = "0.30.0"
+source = "git+https://github.com/dvc94ch/rust-libp2p?branch=sim-open#f096d31deabe0e4eaf08ea2c1dd63ceb5574bf94"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -1880,6 +1886,7 @@ dependencies = [
 [[package]]
 name = "libp2p-pnet"
 version = "0.21.0"
+source = "git+https://github.com/dvc94ch/rust-libp2p?branch=sim-open#f096d31deabe0e4eaf08ea2c1dd63ceb5574bf94"
 dependencies = [
  "futures",
  "log",
@@ -1916,6 +1923,7 @@ dependencies = [
 [[package]]
 name = "libp2p-request-response"
 version = "0.12.0"
+source = "git+https://github.com/dvc94ch/rust-libp2p?branch=sim-open#f096d31deabe0e4eaf08ea2c1dd63ceb5574bf94"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1934,6 +1942,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm"
 version = "0.30.0"
+source = "git+https://github.com/dvc94ch/rust-libp2p?branch=sim-open#f096d31deabe0e4eaf08ea2c1dd63ceb5574bf94"
 dependencies = [
  "either",
  "futures",
@@ -1948,6 +1957,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm-derive"
 version = "0.23.0"
+source = "git+https://github.com/dvc94ch/rust-libp2p?branch=sim-open#f096d31deabe0e4eaf08ea2c1dd63ceb5574bf94"
 dependencies = [
  "quote",
  "syn",
@@ -1956,6 +1966,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tcp"
 version = "0.29.0"
+source = "git+https://github.com/dvc94ch/rust-libp2p?branch=sim-open#f096d31deabe0e4eaf08ea2c1dd63ceb5574bf94"
 dependencies = [
  "async-io",
  "futures",
@@ -1973,6 +1984,7 @@ dependencies = [
 [[package]]
 name = "libp2p-yamux"
 version = "0.33.0"
+source = "git+https://github.com/dvc94ch/rust-libp2p?branch=sim-open#f096d31deabe0e4eaf08ea2c1dd63ceb5574bf94"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -2257,6 +2269,7 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 [[package]]
 name = "multistream-select"
 version = "0.10.3"
+source = "git+https://github.com/dvc94ch/rust-libp2p?branch=sim-open#f096d31deabe0e4eaf08ea2c1dd63ceb5574bf94"
 dependencies = [
  "bytes",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,7 +6,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fc95d1bdb8e6666b2b217308eeeb09f2d6728d104be3e31916cc74d15420331"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array",
 ]
 
 [[package]]
@@ -15,7 +15,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "922b33332f54fc0ad13fa3e514601e8d30fb54e1f3eadc36643f6526db645621"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array",
 ]
 
 [[package]]
@@ -31,14 +31,14 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2333ac5777aaa1beb8589f5374976ae7dc8aa4f09fd21ae3d8662ca97f5247d"
+checksum = "495ee669413bfbe9e8cace80f4d3d78e6d8c8d99579f97fb93bde351b185f2d4"
 dependencies = [
  "cfg-if 1.0.0",
  "cipher 0.3.0",
  "cpufeatures",
- "opaque-debug 0.3.0",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -52,21 +52,21 @@ dependencies = [
  "cipher 0.2.5",
  "ctr 0.6.0",
  "ghash 0.3.1",
- "subtle 2.4.0",
+ "subtle",
 ]
 
 [[package]]
 name = "aes-gcm"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ee2263805ba4537ccbb19db28525a7b1ebc7284c228eb5634c3124ca63eb03f"
+checksum = "bc3be92e19a7ef47457b8e6f90707e12b6ac5d20c6f3866584fa3be0787d839f"
 dependencies = [
  "aead 0.4.1",
- "aes 0.7.3",
+ "aes 0.7.4",
  "cipher 0.3.0",
  "ctr 0.7.0",
- "ghash 0.4.1",
- "subtle 2.4.0",
+ "ghash 0.4.2",
+ "subtle",
 ]
 
 [[package]]
@@ -76,7 +76,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be14c7498ea50828a38d0e24a765ed2effe92a705885b57d029cd67d45744072"
 dependencies = [
  "cipher 0.2.5",
- "opaque-debug 0.3.0",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -86,7 +86,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2e11f5e94c2f7d386164cc2aa1f97823fed6f259e486940a71c174dd01b0ce"
 dependencies = [
  "cipher 0.2.5",
- "opaque-debug 0.3.0",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -309,7 +309,7 @@ dependencies = [
  "rand 0.7.3",
  "serde",
  "serde_json",
- "sha2 0.9.5",
+ "sha2",
 ]
 
 [[package]]
@@ -471,8 +471,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10a5720225ef5daecf08657f23791354e1685a8c91a4c60c7f3d3b2892f978f4"
 dependencies = [
  "crypto-mac 0.8.0",
- "digest 0.9.0",
- "opaque-debug 0.3.0",
+ "digest",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -487,19 +487,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "constant_time_eq",
  "crypto-mac 0.8.0",
- "digest 0.9.0",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
-dependencies = [
- "block-padding 0.1.5",
- "byte-tools",
- "byteorder",
- "generic-array 0.12.4",
+ "digest",
 ]
 
 [[package]]
@@ -508,17 +496,8 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "block-padding 0.2.1",
- "generic-array 0.14.4",
-]
-
-[[package]]
-name = "block-padding"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
-dependencies = [
- "byte-tools",
+ "block-padding",
+ "generic-array",
 ]
 
 [[package]]
@@ -562,12 +541,6 @@ dependencies = [
  "crossbeam-queue",
  "stable_deref_trait",
 ]
-
-[[package]]
-name = "byte-tools"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "byteorder"
@@ -671,7 +644,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12f8e7987cbd042a63249497f41aed09f8e65add917ea6566effbc56578d6801"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array",
 ]
 
 [[package]]
@@ -680,7 +653,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array",
 ]
 
 [[package]]
@@ -737,7 +710,7 @@ dependencies = [
  "hmac 0.10.1",
  "percent-encoding",
  "rand 0.8.3",
- "sha2 0.9.5",
+ "sha2",
  "time 0.2.26",
  "version_check",
 ]
@@ -785,22 +758,12 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-mac"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
-dependencies = [
- "generic-array 0.12.4",
- "subtle 1.0.0",
-]
-
-[[package]]
-name = "crypto-mac"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
- "generic-array 0.14.4",
- "subtle 2.4.0",
+ "generic-array",
+ "subtle",
 ]
 
 [[package]]
@@ -809,8 +772,8 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4857fd85a0c34b3c3297875b747c1e02e06b6a0ea32dd892d8192b9ce0813ea6"
 dependencies = [
- "generic-array 0.14.4",
- "subtle 2.4.0",
+ "generic-array",
+ "subtle",
 ]
 
 [[package]]
@@ -848,9 +811,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "639891fde0dbea823fc3d798a0fdf9d2f9440a42d64a78ab3488b0ca025117b3"
 dependencies = [
  "byteorder",
- "digest 0.9.0",
+ "digest",
  "rand_core 0.5.1",
- "subtle 2.4.0",
+ "subtle",
  "zeroize",
 ]
 
@@ -904,20 +867,11 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
-dependencies = [
- "generic-array 0.12.4",
-]
-
-[[package]]
-name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array",
 ]
 
 [[package]]
@@ -955,7 +909,7 @@ dependencies = [
  "ed25519",
  "rand 0.7.3",
  "serde",
- "sha2 0.9.5",
+ "sha2",
  "zeroize",
 ]
 
@@ -982,12 +936,6 @@ name = "event-listener"
 version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7531096570974c3a9dcf9e4b8e1cede1ec26cf5046219fb3b9d897503b9be59"
-
-[[package]]
-name = "fake-simd"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
 name = "fallible-iterator"
@@ -1105,9 +1053,9 @@ checksum = "acc499defb3b348f8d8f3f66415835a9131856ff7714bf10dadfc4ec4bdb29a1"
 
 [[package]]
 name = "futures-lite"
-version = "1.11.3"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4481d0cd0de1d204a4fa55e7d45f07b1d958abcb06714b3446438e2eff695fb"
+checksum = "7694489acd39452c77daa48516b894c153f192c3578d5a839b62c58099fcbf48"
 dependencies = [
  "fastrand",
  "futures-core",
@@ -1172,15 +1120,6 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
-dependencies = [
- "typenum",
-]
-
-[[package]]
-name = "generic-array"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
@@ -1217,18 +1156,18 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97304e4cd182c3846f7575ced3890c53012ce534ad9114046b0a9e00bb30a375"
 dependencies = [
- "opaque-debug 0.3.0",
+ "opaque-debug",
  "polyval 0.4.5",
 ]
 
 [[package]]
 name = "ghash"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6fb2a26dd2ebd268a68bc8e9acc9e67e487952f33384055a1cbe697514c64e"
+checksum = "7bbd60caa311237d508927dbba7594b483db3ef05faa55172fcf89b1bcda7853"
 dependencies = [
- "opaque-debug 0.3.0",
- "polyval 0.5.0",
+ "opaque-debug",
+ "polyval 0.5.1",
 ]
 
 [[package]]
@@ -1273,9 +1212,9 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cbf45460356b7deeb5e3415b5563308c0a9b057c85e12b06ad551f98d0a6ac"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -1307,18 +1246,8 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51ab2f639c231793c5f6114bdb9bbe50a7dbbfcd7c7c6bd8475dec2d991e964f"
 dependencies = [
- "digest 0.9.0",
+ "digest",
  "hmac 0.10.1",
-]
-
-[[package]]
-name = "hmac"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dcb5e64cda4c23119ab41ba960d1e170a774c8e4b9d9e6a9bc18aabf5e59695"
-dependencies = [
- "crypto-mac 0.7.0",
- "digest 0.8.1",
 ]
 
 [[package]]
@@ -1328,7 +1257,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "126888268dcc288495a26bf004b38c5fdbb31682f992c84ceb046a1f0fe38840"
 dependencies = [
  "crypto-mac 0.8.0",
- "digest 0.9.0",
+ "digest",
 ]
 
 [[package]]
@@ -1338,18 +1267,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
 dependencies = [
  "crypto-mac 0.10.0",
- "digest 0.9.0",
+ "digest",
 ]
 
 [[package]]
 name = "hmac-drbg"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6e570451493f10f6581b48cdd530413b63ea9e780f544bfd3bdcaa0d89d1a7b"
+checksum = "17ea0a1394df5b6574da6e0c1ade9e78868c9fb0a4e5ef4428e32da4676b85b1"
 dependencies = [
- "digest 0.8.1",
- "generic-array 0.12.4",
- "hmac 0.7.1",
+ "digest",
+ "generic-array",
+ "hmac 0.8.1",
 ]
 
 [[package]]
@@ -1509,7 +1438,7 @@ dependencies = [
  "ipfs-sqlite-block-store",
  "lazy_static",
  "libipld",
- "libp2p 0.38.0",
+ "libp2p",
  "libp2p-bitswap",
  "libp2p-broadcast",
  "libp2p-quic",
@@ -1532,7 +1461,9 @@ name = "ipfs-embed-cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-process",
  "async-std",
+ "ed25519-dalek",
  "ipfs-embed",
  "libipld",
  "multihash 0.14.0",
@@ -1551,6 +1482,7 @@ dependencies = [
  "futures",
  "ipfs-embed-cli",
  "libipld",
+ "libp2p",
  "multihash 0.14.0",
  "netsim-embed",
  "rand 0.8.3",
@@ -1712,29 +1644,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p"
-version = "0.37.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08053fbef67cd777049ef7a95ebaca2ece370b4ed7712c3fa404d69a88cb741b"
-dependencies = [
- "atomic",
- "bytes",
- "futures",
- "lazy_static",
- "libp2p-core",
- "libp2p-swarm",
- "libp2p-swarm-derive",
- "parity-multiaddr",
- "parking_lot",
- "pin-project 1.0.7",
- "smallvec",
- "wasm-timer",
-]
-
-[[package]]
-name = "libp2p"
 version = "0.38.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebbb17eece4aec5bb970880c73825c16ca59ca05a4e41803751e68c7e5f0c618"
 dependencies = [
  "atomic",
  "bytes",
@@ -1755,7 +1665,7 @@ dependencies = [
  "libp2p-swarm-derive",
  "libp2p-tcp",
  "libp2p-yamux",
- "parity-multiaddr",
+ "multiaddr",
  "parking_lot",
  "pin-project 1.0.7",
  "smallvec",
@@ -1773,7 +1683,7 @@ dependencies = [
  "futures",
  "lazy_static",
  "libipld",
- "libp2p 0.38.0",
+ "libp2p",
  "prometheus",
  "prost",
  "prost-build",
@@ -1790,14 +1700,12 @@ checksum = "72cb0e39c68735f5b5f81e61a9b2ce99fa5ff47c2bb69208764d3548dc3d37e8"
 dependencies = [
  "fnv",
  "futures",
- "libp2p 0.38.0",
+ "libp2p",
 ]
 
 [[package]]
 name = "libp2p-core"
-version = "0.28.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "554d3e7e9e65f939d66b75fd6a4c67f258fe250da61b91f46c545fc4a89b51d9"
+version = "0.29.0"
 dependencies = [
  "asn1_der",
  "bs58",
@@ -1809,9 +1717,9 @@ dependencies = [
  "lazy_static",
  "libsecp256k1",
  "log",
+ "multiaddr",
  "multihash 0.13.2",
  "multistream-select",
- "parity-multiaddr",
  "parking_lot",
  "pin-project 1.0.7",
  "prost",
@@ -1819,7 +1727,7 @@ dependencies = [
  "rand 0.7.3",
  "ring",
  "rw-stream-sink",
- "sha2 0.9.5",
+ "sha2",
  "smallvec",
  "thiserror",
  "unsigned-varint 0.7.0",
@@ -1829,9 +1737,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-dns"
-version = "0.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e63dab8b5ff35e0c101a3e51e843ba782c07bbb1682f5fd827622e0d02b98b"
+version = "0.29.0"
 dependencies = [
  "async-std-resolver",
  "futures",
@@ -1843,9 +1749,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-gossipsub"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e562308761818b0c52f2a81a0544b9c22d0cf56d7b2d928a0ff61382404498ce"
+version = "0.32.0"
 dependencies = [
  "asynchronous-codec",
  "base64 0.13.0",
@@ -1861,7 +1765,7 @@ dependencies = [
  "prost-build",
  "rand 0.7.3",
  "regex",
- "sha2 0.9.5",
+ "sha2",
  "smallvec",
  "unsigned-varint 0.7.0",
  "wasm-timer",
@@ -1869,9 +1773,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-identify"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f668f00efd9883e8b7bcc582eaf0164615792608f886f6577da18bcbeea0a46"
+version = "0.30.0"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -1885,9 +1787,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-kad"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b07312ebe5ee4fd2404447a0609814574df55c65d4e20838b957bbd34907d820"
+version = "0.31.0"
 dependencies = [
  "arrayvec",
  "asynchronous-codec",
@@ -1901,7 +1801,7 @@ dependencies = [
  "prost",
  "prost-build",
  "rand 0.7.3",
- "sha2 0.9.5",
+ "sha2",
  "smallvec",
  "uint",
  "unsigned-varint 0.7.0",
@@ -1911,9 +1811,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-mdns"
-version = "0.30.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4efa70c1c3d2d91237f8546e27aeb85e287d62c066a7b4f3ea6a696d43ced714"
+version = "0.31.0"
 dependencies = [
  "async-io",
  "data-encoding",
@@ -1932,9 +1830,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-mplex"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85e9b544335d1ed30af71daa96edbefadef6f19c7a55f078b9fc92c87163105d"
+version = "0.29.0"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -1950,9 +1846,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-noise"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a2aa6fc4e6855eaf9ea1941a14f7ec4df35636fb6b85951e17481df8dcecf6"
+version = "0.32.0"
 dependencies = [
  "bytes",
  "curve25519-dalek",
@@ -1963,7 +1857,7 @@ dependencies = [
  "prost",
  "prost-build",
  "rand 0.8.3",
- "sha2 0.9.5",
+ "sha2",
  "snow",
  "static_assertions",
  "x25519-dalek",
@@ -1972,9 +1866,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-ping"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4bfaffac63bf3c7ec11ed9d8879d455966ddea7e78ee14737f0b6dce0d1cd1"
+version = "0.30.0"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -1988,8 +1880,6 @@ dependencies = [
 [[package]]
 name = "libp2p-pnet"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07cb4dd4b917e5b40ddefe49b96b07adcd8d342e0317011d175b7b2bb1dcc974"
 dependencies = [
  "futures",
  "log",
@@ -2001,9 +1891,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-quic"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed6db1386190ddc1be4cd36f19987227cdfb8dd49b0ee34cdacddc2c401c2f9"
+checksum = "f3197e2565d33fd8bf208ee6ecde327a2de99adb0978f0284b91b0dcf25e0153"
 dependencies = [
  "anyhow",
  "async-global-executor",
@@ -2012,7 +1902,7 @@ dependencies = [
  "fnv",
  "futures",
  "if-watch",
- "libp2p 0.37.1",
+ "libp2p",
  "multihash 0.13.2",
  "parking_lot",
  "quinn-noise",
@@ -2025,9 +1915,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-request-response"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cdbe172f08e6d0f95fa8634e273d4c4268c4063de2e33e7435194b0130c62e3"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2045,9 +1933,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-swarm"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e04d8e1eef675029ec728ba14e8d0da7975d84b6679b699b4ae91a1de9c3a92"
+version = "0.30.0"
 dependencies = [
  "either",
  "futures",
@@ -2062,8 +1948,6 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm-derive"
 version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "365b0a699fea5168676840567582a012ea297b1ca02eee467e58301b9c9c5eed"
 dependencies = [
  "quote",
  "syn",
@@ -2071,9 +1955,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-tcp"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b1a27d21c477951799e99d5c105d78868258502ce092988040a808d5a19bbd9"
+version = "0.29.0"
 dependencies = [
  "async-io",
  "futures",
@@ -2090,9 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-yamux"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f35da42cfc6d5cb0dcf3ad6881bc68d146cdf38f98655e09e33fbba4d13eabc4"
+version = "0.33.0"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -2131,18 +2011,50 @@ dependencies = [
 
 [[package]]
 name = "libsecp256k1"
-version = "0.3.5"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc1e2c808481a63dc6da2074752fdd4336a3c8fcc68b83db6f1fd5224ae7962"
+checksum = "bd1137239ab33b41aa9637a88a28249e5e70c40a42ccc92db7f12cc356c1fcd7"
 dependencies = [
  "arrayref",
- "crunchy",
- "digest 0.8.1",
+ "base64 0.12.3",
+ "digest",
  "hmac-drbg",
+ "libsecp256k1-core",
+ "libsecp256k1-gen-ecmult",
+ "libsecp256k1-gen-genmult",
  "rand 0.7.3",
- "sha2 0.8.2",
- "subtle 2.4.0",
+ "serde",
+ "sha2",
  "typenum",
+]
+
+[[package]]
+name = "libsecp256k1-core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daaa407ce05dc49849836840fb2542edcadafc4f55e314840cbb5b49359a6919"
+dependencies = [
+ "crunchy",
+ "digest",
+ "subtle",
+]
+
+[[package]]
+name = "libsecp256k1-gen-ecmult"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32239626ffbb6a095b83b37a02ceb3672b2443a87a000a884fc3c4d16925c9c0"
+dependencies = [
+ "libsecp256k1-core",
+]
+
+[[package]]
+name = "libsecp256k1-gen-genmult"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76acb433e21d10f5f9892b1962c2856c58c7f39a9e4bd68ac82b9436a0ffd5b9"
+dependencies = [
+ "libsecp256k1-core",
 ]
 
 [[package]]
@@ -2269,6 +2181,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "multiaddr"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7139982f583d7e53879d9f611fe48ced18e77d684309484f2252c76bcd39f549"
+dependencies = [
+ "arrayref",
+ "bs58",
+ "byteorder",
+ "data-encoding",
+ "multihash 0.13.2",
+ "percent-encoding",
+ "serde",
+ "static_assertions",
+ "unsigned-varint 0.7.0",
+ "url",
+]
+
+[[package]]
 name = "multibase"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2285,10 +2215,10 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dac63698b887d2d929306ea48b63760431ff8a24fac40ddb22f9c7f49fb7cab"
 dependencies = [
- "digest 0.9.0",
- "generic-array 0.14.4",
+ "digest",
+ "generic-array",
  "multihash-derive",
- "sha2 0.9.5",
+ "sha2",
  "unsigned-varint 0.5.1",
 ]
 
@@ -2299,7 +2229,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "752a61cd890ff691b4411423d23816d5866dd5621e4d1c5687a53b94b5a979d8"
 dependencies = [
  "blake3",
- "generic-array 0.14.4",
+ "generic-array",
  "multihash-derive",
  "unsigned-varint 0.7.0",
 ]
@@ -2326,14 +2256,13 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "multistream-select"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d91ec0a2440aaff5f78ec35631a7027d50386c6163aa975f7caa0d5da4b6ff8"
+version = "0.10.3"
 dependencies = [
  "bytes",
  "futures",
  "log",
  "pin-project 1.0.7",
+ "rand 0.7.3",
  "smallvec",
  "unsigned-varint 0.7.0",
 ]
@@ -2349,9 +2278,9 @@ dependencies = [
 
 [[package]]
 name = "netsim-embed"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7156dcd13b1c6bd616da2b8053b08a2a2124ea5120dbb7f3870902294ebdf45"
+checksum = "27a8be88c31bc2b8219e231f2981c12420c13a3664ea9d3995d5c3ad0ec20818"
 dependencies = [
  "async-global-executor",
  "async-process",
@@ -2366,9 +2295,9 @@ dependencies = [
 
 [[package]]
 name = "netsim-embed-core"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a392eb891633c8c4cf6733549d91a4ecc98c5217138361ca8a46413fcab9e8fa"
+checksum = "b2b92241116c80c5aa3905e98f2e3932b5e66be85b8290dbe4b209aac82b527d"
 dependencies = [
  "async-global-executor",
  "async-io",
@@ -2471,33 +2400,9 @@ checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
 
 [[package]]
 name = "opaque-debug"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
-
-[[package]]
-name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
-
-[[package]]
-name = "parity-multiaddr"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58341485071825827b7f03cf7efd1cb21e6a709bea778fb50227fd45d2f361b4"
-dependencies = [
- "arrayref",
- "bs58",
- "byteorder",
- "data-encoding",
- "multihash 0.13.2",
- "percent-encoding",
- "serde",
- "static_assertions",
- "unsigned-varint 0.7.0",
- "url",
-]
 
 [[package]]
 name = "parking"
@@ -2639,7 +2544,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fe800695325da85083cd23b56826fccb2e2dc29b218e7811a6f33bc93f414be"
 dependencies = [
  "cpufeatures",
- "opaque-debug 0.3.0",
+ "opaque-debug",
  "universal-hash",
 ]
 
@@ -2650,18 +2555,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eebcc4aa140b9abd2bc40d9c3f7ccec842679cd79045ac3a7ac698c1a064b7cd"
 dependencies = [
  "cpuid-bool",
- "opaque-debug 0.3.0",
+ "opaque-debug",
  "universal-hash",
 ]
 
 [[package]]
 name = "polyval"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "864231b0b86ce05168a8e6da0fea2e67275dacf25f75b00a62cfd341aab904a9"
+checksum = "e597450cbf209787f0e6de80bf3795c6b2356a380ee87837b545aded8dbc1823"
 dependencies = [
+ "cfg-if 1.0.0",
  "cpufeatures",
- "opaque-debug 0.3.0",
+ "opaque-debug",
  "universal-hash",
 ]
 
@@ -2817,8 +2723,8 @@ dependencies = [
  "quinn-proto",
  "rand_core 0.5.1",
  "ring",
- "sha2 0.9.5",
- "subtle 2.4.0",
+ "sha2",
+ "subtle",
  "tracing",
  "x25519-dalek",
  "xoodoo",
@@ -3005,11 +2911,10 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 dependencies = [
- "byteorder",
  "regex-syntax",
 ]
 
@@ -3220,27 +3125,15 @@ checksum = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
 
 [[package]]
 name = "sha2"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a256f46ea78a0c0d9ff00077504903ac881a1dafdc20da66545699e7776b3e69"
-dependencies = [
- "block-buffer 0.7.3",
- "digest 0.8.1",
- "fake-simd",
- "opaque-debug 0.2.3",
-]
-
-[[package]]
-name = "sha2"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b362ae5752fd2137731f9fa25fd4d9058af34666ca1966fb969119cc35719f12"
 dependencies = [
- "block-buffer 0.9.0",
+ "block-buffer",
  "cfg-if 1.0.0",
  "cpufeatures",
- "digest 0.9.0",
- "opaque-debug 0.3.0",
+ "digest",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -3249,10 +3142,10 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
 dependencies = [
- "block-buffer 0.9.0",
- "digest 0.9.0",
+ "block-buffer",
+ "digest",
  "keccak",
- "opaque-debug 0.3.0",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -3266,9 +3159,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef33d6d0cd06e0840fba9985aab098c147e67e05cee14d412d3345ed14ff30ac"
+checksum = "470c5a6397076fae0094aaf06a08e6ba6f37acb77d3b1b91ea92b4d6c8650c39"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -3276,9 +3169,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16f1d0fef1604ba8f7a073c7e701f213e056707210e9020af4528e0101ce11a6"
+checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
 dependencies = [
  "libc",
 ]
@@ -3316,15 +3209,15 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6142f7c25e94f6fd25a32c3348ec230df9109b463f59c8c7acc4bd34936babb7"
 dependencies = [
- "aes-gcm 0.9.1",
+ "aes-gcm 0.9.2",
  "blake2",
  "chacha20poly1305",
  "rand 0.8.3",
  "rand_core 0.6.2",
  "ring",
  "rustc_version 0.3.3",
- "sha2 0.9.5",
- "subtle 2.4.0",
+ "sha2",
+ "subtle",
  "x25519-dalek",
 ]
 
@@ -3454,12 +3347,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "subtle"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 
 [[package]]
 name = "subtle"
@@ -3833,9 +3720,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33717dca7ac877f497014e10d73f3acf948c342bee31b5ca7892faf94ccc6b49"
+checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
 dependencies = [
  "tinyvec",
 ]
@@ -3864,8 +3751,8 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8326b2c654932e3e4f9196e69d08fdf7cfd718e1dc6f66b347e6024a0c961402"
 dependencies = [
- "generic-array 0.14.4",
- "subtle 2.4.0",
+ "generic-array",
+ "subtle",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1494,9 +1494,9 @@ dependencies = [
 
 [[package]]
 name = "ipfs-sqlite-block-store"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4359b2e5e7f48f54351d668c2f423de61a0e6a0e581c4732f3169579f3bd64d"
+checksum = "8e4bfde6259c565dc55fd3c26b75ad29481e29105c0f2035a674b5b80e568fdc"
 dependencies = [
  "anyhow",
  "derive_more",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,3 +62,6 @@ tracing-subscriber = "0.2.18"
 
 [profile.release]
 debug = true
+
+[patch.crates-io]
+libp2p = { path = "../rust-libp2p" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ lazy_static = "1.4.0"
 libipld = { version = "0.12.0", default-features = false }
 libp2p-bitswap = "0.18.0"
 libp2p-broadcast = "0.4.0"
-libp2p-quic = "0.3.1"
+libp2p-quic = "0.4.0"
 names = "0.11.0"
 parking_lot = "0.11.1"
 pin-project = "1.0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,10 @@ futures = "0.3.15"
 ipfs-sqlite-block-store = "0.6.0"
 lazy_static = "1.4.0"
 libipld = { version = "0.12.0", default-features = false }
-libp2p-bitswap = "0.18.0"
-libp2p-broadcast = "0.4.0"
+#libp2p-bitswap = "0.18.0"
+libp2p-bitswap = { git = "https://github.com/ipfs-rust/libp2p-bitswap", branch = "sim-open" }
+#libp2p-broadcast = "0.4.0"
+libp2p-broadcast = { git = "https://github.com/ipfs-rust/libp2p-broadcast", branch = "sim-open" }
 libp2p-quic = "0.4.0"
 names = "0.11.0"
 parking_lot = "0.11.1"
@@ -55,7 +57,7 @@ features = [
 [dev-dependencies]
 async-std = { version = "1.9.0", features = ["attributes"] }
 libipld = { version = "0.12.0", default-features = false, features = ["dag-cbor", "dag-pb", "derive"] }
-libp2p-bitswap = { version = "0.18.0", default-features = false, features = ["compat"] }
+#libp2p-bitswap = { version = "0.18.0", default-features = false, features = ["compat"] }
 multihash = { version = "0.14.0", default-features = false, features = ["blake3"] }
 rand = "0.8.3"
 tracing-subscriber = "0.2.18"
@@ -64,4 +66,4 @@ tracing-subscriber = "0.2.18"
 debug = true
 
 [patch.crates-io]
-libp2p = { path = "../rust-libp2p" }
+libp2p = { git = "https://github.com/dvc94ch/rust-libp2p", branch = "sim-open" }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -7,7 +7,9 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.40"
+async-process = "1.1.0"
 async-std = { version = "1.9.0", features = ["attributes"] }
+ed25519-dalek = "1.0.1"
 ipfs-embed = { path = ".." }
 libipld = { version = "0.12.0", default-features = false, features = ["dag-cbor"] }
 multihash = { version = "0.14.0", default-features = false, features = ["blake3"] }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,9 +1,9 @@
 use anyhow::Result;
 use async_std::stream::StreamExt;
-use ipfs_embed::multiaddr::Protocol;
-use ipfs_embed::{DefaultParams, Ipfs, ListenerEvent};
-use ipfs_embed_cli::{Command, Config, Event};
+use ipfs_embed::{DefaultParams, Ipfs, NetworkConfig, StorageConfig};
+use ipfs_embed_cli::{keypair, Command, Config, Event};
 use std::io::Write;
+use std::time::Duration;
 use structopt::StructOpt;
 
 #[async_std::main]
@@ -21,33 +21,82 @@ async fn run() -> Result<()> {
     let mut stdout = std::io::stdout();
     let mut line = String::with_capacity(4096);
 
-    let ipfs = Ipfs::<DefaultParams>::new(Config::from_args().into()).await?;
-    let peer_id = ipfs.local_peer_id();
+    let config = Config::from_args();
+    let sweep_interval = Duration::from_millis(10000);
+    let storage = StorageConfig::new(config.path, 10, sweep_interval);
+
+    let mut network = NetworkConfig {
+        node_key: keypair(config.keypair),
+        mdns: if config.enable_mdns {
+            Some(Default::default())
+        } else {
+            None
+        },
+        kad: None,
+        ..Default::default()
+    };
+    let node_name = if let Some(node_name) = config.node_name {
+        node_name
+    } else {
+        format!("node{}", config.keypair)
+    };
+    network.identify.as_mut().unwrap().agent_version = node_name;
+
+    let ipfs = Ipfs::<DefaultParams>::new(ipfs_embed::Config { storage, network }).await?;
+    let mut events = ipfs.swarm_events();
+
+    for addr in config.listen_on {
+        let _ = ipfs.listen_on(addr)?;
+    }
+
+    for addr in config.external {
+        ipfs.add_external_address(addr);
+    }
+
+    if !config.bootstrap.is_empty() {
+        //ipfs.bootstrap(config.bootstrap)
+        unimplemented!()
+    }
+
+    async_std::task::spawn(async move {
+        while let Some(event) = events.next().await {
+            let event = match event {
+                ipfs_embed::Event::NewListener(_) => Some(Event::NewListener),
+                ipfs_embed::Event::NewListenAddr(_, addr) => Some(Event::NewListenAddr(addr)),
+                ipfs_embed::Event::ExpiredListenAddr(_, addr) => {
+                    Some(Event::ExpiredListenAddr(addr))
+                }
+                ipfs_embed::Event::ListenerClosed(_) => Some(Event::ListenerClosed),
+                ipfs_embed::Event::NewExternalAddr(addr) => Some(Event::NewExternalAddr(addr)),
+                ipfs_embed::Event::ExpiredExternalAddr(addr) => {
+                    Some(Event::ExpiredExternalAddr(addr))
+                }
+                ipfs_embed::Event::Discovered(peer_id) => Some(Event::Discovered(peer_id)),
+                ipfs_embed::Event::Unreachable(peer_id) => Some(Event::Unreachable(peer_id)),
+                ipfs_embed::Event::Connected(peer_id) => Some(Event::Connected(peer_id)),
+                ipfs_embed::Event::Disconnected(peer_id) => Some(Event::Disconnected(peer_id)),
+                ipfs_embed::Event::Subscribed(peer_id, topic) => {
+                    Some(Event::Subscribed(peer_id, topic))
+                }
+                ipfs_embed::Event::Unsubscribed(peer_id, topic) => {
+                    Some(Event::Unsubscribed(peer_id, topic))
+                }
+            };
+            if let Some(event) = event {
+                println!("{}", event);
+            }
+        }
+    });
 
     loop {
         line.clear();
         stdin.read_line(&mut line)?;
         match line.parse()? {
-            Command::ListenOn(addr) => {
-                let mut listener = ipfs.listen_on(addr)?;
-                let addr = loop {
-                    match listener.next().await {
-                        Some(ListenerEvent::NewListenAddr(addr)) => {
-                            if let Some(Protocol::Ip4(ip)) = addr.iter().next() {
-                                if !ip.is_loopback() {
-                                    break addr;
-                                }
-                            }
-                        }
-                        _ => return Err(anyhow::anyhow!("failed to bind address")),
-                    }
-                };
-                writeln!(stdout, "{}", Event::ListeningOn(peer_id, addr))?;
-            }
             Command::AddAddress(peer, addr) => {
-                if peer != peer_id {
-                    ipfs.add_address(&peer, addr);
-                }
+                ipfs.add_address(&peer, addr);
+            }
+            Command::Dial(peer) => {
+                ipfs.dial(&peer);
             }
             Command::Get(cid) => {
                 let block = ipfs.get(&cid)?;

--- a/harness/Cargo.toml
+++ b/harness/Cargo.toml
@@ -12,8 +12,9 @@ async-process = "1.1.0"
 futures = "0.3.15"
 ipfs-embed-cli = { path = "../cli" }
 libipld = { version = "0.12.0", default-features = false, features = ["dag-cbor", "dag-pb", "derive"] }
+libp2p = { version = "0.38.0", default-features = false }
 multihash = { version = "0.14.0", default-features = false, features = ["blake3"] }
-netsim-embed = "0.4.2"
+netsim-embed = "0.5.0"
 rand = "0.8.3"
 structopt = "0.3.21"
 tempdir = "0.3.7"

--- a/harness/src/bin/sim_open.rs
+++ b/harness/src/bin/sim_open.rs
@@ -1,0 +1,92 @@
+#[cfg(target_os = "linux")]
+fn main() -> anyhow::Result<()> {
+    use ipfs_embed_cli::{Config, Command, Event};
+    use ipfs_embed_harness::{MachineExt, MultiaddrExt};
+    use netsim_embed::{DelayBuffer, Ipv4Range, Netsim};
+    use std::time::Duration;
+
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+    netsim_embed::unshare_user()?;
+    async_global_executor::block_on(async move {
+        let mut sim = Netsim::new();
+        let net = sim.spawn_network(Ipv4Range::random_local_subnet());
+
+        let mut wire = DelayBuffer::new();
+        wire.set_delay(Duration::from_millis(100));
+        let a = sim.spawn_machine(Config::new(0).into(), Some(wire)).await;
+        sim.plug(a, net, None).await;
+
+        let mut wire = DelayBuffer::new();
+        wire.set_delay(Duration::from_millis(100));
+        let b = sim.spawn_machine(Config::new(1).into(), Some(wire)).await;
+        sim.plug(b, net, None).await;
+
+        let ms = sim.machines_mut();
+        let (a, ms) = ms.split_at_mut(1);
+        let a = &mut a[0];
+        let (b, _) = ms.split_at_mut(1);
+        let b = &mut b[0];
+        let a_id = a.peer_id();
+        let a_addr = a.multiaddr();
+        let b_id = b.peer_id();
+        let b_addr = b.multiaddr();
+
+        loop {
+            if let Some(Event::NewListenAddr(addr)) = a.recv().await {
+                if !addr.is_loopback() {
+                    break;
+                }
+            }
+        }
+
+        loop {
+            if let Some(Event::NewListenAddr(addr)) = b.recv().await {
+                if !addr.is_loopback() {
+                    break;
+                }
+            }
+        }
+
+        a.send(Command::AddAddress(b_id, b_addr));
+        b.send(Command::AddAddress(a_id, a_addr));
+        a.send(Command::Dial(b_id));
+        b.send(Command::Dial(a_id));
+
+        loop {
+            match a.recv().await {
+                Some(Event::Connected(id)) => {
+                    if id == b_id {
+                        break;
+                    }
+                }
+                Some(Event::Unreachable(id)) => {
+                    if id == b_id {
+                        return Err(anyhow::anyhow!("sim open failed"));
+                    }
+                }
+                _ => {}
+            }
+        }
+        loop {
+            match b.recv().await {
+                Some(Event::Connected(id)) => {
+                    if id == a_id {
+                        break;
+                    }
+                }
+                Some(Event::Unreachable(id)) => {
+                    if id == a_id {
+                        return Err(anyhow::anyhow!("sim open failed"));
+                    }
+                }
+                _ => {}
+            }
+        }
+        Ok(())
+    })
+}
+
+#[cfg(not(target_os = "linux"))]
+fn main() {}

--- a/harness/src/bin/sim_open.rs
+++ b/harness/src/bin/sim_open.rs
@@ -1,6 +1,6 @@
 #[cfg(target_os = "linux")]
 fn main() -> anyhow::Result<()> {
-    use ipfs_embed_cli::{Config, Command, Event};
+    use ipfs_embed_cli::{Command, Config, Event};
     use ipfs_embed_harness::{MachineExt, MultiaddrExt};
     use netsim_embed::{DelayBuffer, Ipv4Range, Netsim};
     use std::time::Duration;

--- a/harness/src/lib.rs
+++ b/harness/src/lib.rs
@@ -2,10 +2,11 @@
 
 use anyhow::Result;
 use futures::prelude::*;
-use ipfs_embed_cli::{Command, Event};
+use ipfs_embed_cli::{Command, Config, Event};
 use libipld::cbor::DagCborCodec;
 use libipld::multihash::Code;
 use libipld::{Block, Cid, DagCbor, DefaultParams};
+use libp2p::{multiaddr, Multiaddr, PeerId};
 use netsim_embed::{DelayBuffer, Ipv4Range, Netsim};
 use rand::RngCore;
 use std::time::Duration;
@@ -39,6 +40,36 @@ pub struct HarnessOpts {
     pub tree_depth: u64,
 }
 
+pub trait MachineExt {
+    fn peer_id(&self) -> PeerId;
+    fn multiaddr(&self) -> Multiaddr;
+}
+
+impl<C, E> MachineExt for netsim_embed::Machine<C, E> {
+    fn peer_id(&self) -> PeerId {
+        ipfs_embed_cli::peer_id(self.id().0 as u64)
+    }
+
+    fn multiaddr(&self) -> Multiaddr {
+        format!("/ip4/{}/tcp/30000", self.addr()).parse().unwrap()
+    }
+}
+
+pub trait MultiaddrExt {
+    fn is_loopback(&self) -> bool;
+}
+
+impl MultiaddrExt for Multiaddr {
+    fn is_loopback(&self) -> bool {
+        if let Some(multiaddr::Protocol::Ip4(addr)) = self.iter().next() {
+            if !addr.is_loopback() {
+                return false;
+            }
+        }
+        true
+    }
+}
+
 pub fn run_netsim<F, F2>(mut f: F) -> Result<()>
 where
     F: FnMut(Netsim<Command, Event>, HarnessOpts) -> F2,
@@ -47,29 +78,14 @@ where
     tracing_subscriber::fmt()
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
         .init();
-    let opts = HarnessOpts::from_args();
-    let ipfs_embed_cli = std::env::current_exe()?
-        .parent()
-        .unwrap()
-        .join("ipfs-embed-cli");
-    if !ipfs_embed_cli.exists() {
-        return Err(anyhow::anyhow!(
-            "failed to find the ipfs-embed-cli binary at {}",
-            ipfs_embed_cli.display()
-        ));
-    }
-    let temp_dir = TempDir::new("ipfs-embed-harness")?;
     netsim_embed::unshare_user()?;
+    let opts = HarnessOpts::from_args();
+    let temp_dir = TempDir::new("ipfs-embed-harness")?;
     async_global_executor::block_on(async move {
         let mut sim = Netsim::new();
         let net = sim.spawn_network(Ipv4Range::random_local_subnet());
+        tracing::warn!("using network {:?}", sim.network(net).range());
         for i in 0..opts.n_nodes {
-            let ipfs_embed_cli = ipfs_embed_cli.clone();
-            let path = temp_dir.path().join(i.to_string());
-            let mut wire = DelayBuffer::new();
-            wire.set_delay(Duration::from_millis(opts.delay_ms));
-            let mut cmd = async_process::Command::new(ipfs_embed_cli);
-            cmd.arg("--path").arg(path);
             let name = if i < opts.n_providers {
                 format!("provider{}", i)
             } else if i < opts.n_providers + opts.n_consumers {
@@ -77,12 +93,27 @@ where
             } else {
                 format!("idle{}", i - opts.n_providers - opts.n_consumers)
             };
-            cmd.arg("--node-name").arg(name);
-            if opts.enable_mdns {
-                cmd.arg("--enable-mdns");
-            }
-            let machine = sim.spawn_machine(cmd, Some(wire)).await;
+            let cfg = Config {
+                path: Some(temp_dir.path().join(i.to_string())),
+                node_name: Some(name),
+                keypair: i as _,
+                listen_on: vec!["/ip4/0.0.0.0/tcp/30000".parse().unwrap()],
+                bootstrap: vec![],
+                external: vec![],
+                enable_mdns: opts.enable_mdns,
+            };
+            let mut delay = DelayBuffer::new();
+            delay.set_delay(Duration::from_millis(opts.delay_ms));
+            let cmd = async_process::Command::from(cfg);
+            let machine = sim.spawn_machine(cmd, Some(delay)).await;
             sim.plug(machine, net, None).await;
+            let m = sim.machine(machine);
+            tracing::warn!(
+                "{} started with address {} and peer id {}",
+                machine,
+                m.addr(),
+                m.peer_id(),
+            );
         }
         f(sim, opts).await
     })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ use crate::net::{BitswapStore, NetworkService};
 #[cfg(feature = "telemetry")]
 pub use crate::telemetry::telemetry;
 use async_trait::async_trait;
+pub use db::Batch;
 use executor::Executor;
 use futures::stream::Stream;
 use libipld::codec::References;
@@ -294,6 +295,24 @@ where
         } else {
             Err(BlockNotFound(*cid).into())
         }
+    }
+
+    /// Perform a set of readonly storage operations in a batch
+    pub async fn read_batch<F: FnOnce(&Batch<'_, P>) -> Result<R>, R>(
+        &self,
+        op: &'static str,
+        f: F,
+    ) -> Result<R> {
+        self.storage.ro(op, f)
+    }
+
+    /// Perform a set of read and write storage operations in a batch
+    pub async fn write_batch<F: FnOnce(&mut Batch<'_, P>) -> Result<R>, R>(
+        &self,
+        op: &'static str,
+        f: F,
+    ) -> Result<R> {
+        self.storage.rw(op, f)
     }
 
     /// Either returns a block if it's in the block store or tries to retrieve it from

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -87,7 +87,7 @@ impl<P: StoreParams> NetworkService<P> {
                 .into_authentic(&config.node_key.to_keypair())
                 .unwrap();
             let transport = transport
-                .upgrade(Version::V1)
+                .upgrade(Version::V1SimOpen)
                 .authenticate(NoiseConfig::xx(dh_key).into_authenticated())
                 .multiplex(SelectUpgrade::new(
                     YamuxConfig::default(),


### PR DESCRIPTION
For internals, this has been available for a while via the block store, even though we did not yet take advantage of it.

With this API it is also available for ipfs-embed users, such as actyx.

The concrete use case is to be able to add all blocks of a fast path update in a single transaction, or to be able to do a banyan rewrite fully in memory and only spill over to disk once the memory level is exceeded or the write is done.
