### PR TITLE
Make location of the access file configurable

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -23,7 +23,7 @@ async fn run() -> Result<()> {
 
     let config = Config::from_args();
     let sweep_interval = Duration::from_millis(10000);
-    let storage = StorageConfig::new(config.path, 10, sweep_interval);
+    let storage = StorageConfig::new(config.path, None, 10, sweep_interval);
 
     let mut network = NetworkConfig {
         node_key: keypair(config.keypair),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@ impl Config {
     /// ipfs will use an in-memory block store.
     pub fn new(path: &Path, keypair: Keypair) -> Self {
         let sweep_interval = std::time::Duration::from_millis(10000);
-        let storage = StorageConfig::new(Some(path.join("blocks")), 0, sweep_interval);
+        let storage = StorageConfig::new(Some(path.join("blocks")), None, 0, sweep_interval);
         let network = NetworkConfig::new(path.join("streams"), keypair);
         Self { storage, network }
     }
@@ -528,7 +528,7 @@ mod tests {
     async fn create_store(enable_mdns: bool) -> Result<(Ipfs<DefaultParams>, TempDir)> {
         let tmp = TempDir::new("ipfs-embed")?;
         let sweep_interval = Duration::from_millis(10000);
-        let storage = StorageConfig::new(None, 10, sweep_interval);
+        let storage = StorageConfig::new(None, None, 10, sweep_interval);
 
         let mut network = NetworkConfig::new(tmp.path().into(), generate_keypair());
         if !enable_mdns {
@@ -885,7 +885,7 @@ mod tests {
         tracing_try_init();
         let tmp = TempDir::new("ipfs-embed")?;
         let network = NetworkConfig::new(tmp.path().into(), generate_keypair());
-        let storage = StorageConfig::new(None, 1000000, Duration::from_secs(3600));
+        let storage = StorageConfig::new(None, None, 1000000, Duration::from_secs(3600));
         let ipfs = Ipfs::<DefaultParams>::new(Config { storage, network }).await?;
         let a = create_block(b"a")?;
         let b = create_block(b"b")?;
@@ -902,7 +902,7 @@ mod tests {
         tracing_try_init();
         let tmp = TempDir::new("ipfs-embed")?;
         let network = NetworkConfig::new(tmp.path().into(), generate_keypair());
-        let storage = StorageConfig::new(None, 1000000, Duration::from_secs(3600));
+        let storage = StorageConfig::new(None, None, 1000000, Duration::from_secs(3600));
         let ipfs = Ipfs::<DefaultParams>::new(Config { storage, network }).await?;
         let a = create_block(b"a")?;
         let b = create_block(b"b")?;

--- a/tests/gc.rs
+++ b/tests/gc.rs
@@ -55,7 +55,7 @@ impl DagBuilder {
     async fn new() -> Result<Self> {
         let tmp = TempDir::new("gc-test")?;
         let config = Config {
-            storage: StorageConfig::new(None, 0, Duration::from_secs(1000)),
+            storage: StorageConfig::new(None, None, 0, Duration::from_secs(1000)),
             network: NetworkConfig::new(tmp.path().into(), generate_keypair()),
         };
         let ipfs = Ipfs::new(config).await?;


### PR DESCRIPTION
It is not good to use the same file for both! For the block store you want to be paranoid, whereas for the access store you can be as sloppy as you want. If you lose some updates to the access store or even the entire access store, it is no big deal since this is only used for unpinned data...

This PR also makes the case where you are not interested in persisting accesses faster, since it is using the entirely in memory InMemCacheTracker instead of a sqlite tracker in memory mode.