### PR TITLE
Make sure the gc task does not die too fast

### DIFF
--- a/src/net/peers.rs
+++ b/src/net/peers.rs
@@ -479,6 +479,7 @@ mod tests {
         book.inject_addr_reach_failure(Some(&peer_a), &addr_2, &error);
         book.inject_dial_failure(&peer_a);
         assert_eq!(stream.next().await, Some(Event::Unreachable(peer_a)));
+        #[allow(clippy::needless_collect)]
         let peers = book.peers().collect::<Vec<_>>();
         assert!(peers.is_empty());
     }
@@ -508,6 +509,7 @@ mod tests {
         book.inject_addr_reach_failure(Some(&peer_a), &addr_2, &error);
         book.inject_dial_failure(&peer_a);
         assert_eq!(stream.next().await, Some(Event::Unreachable(peer_a)));
+        #[allow(clippy::needless_collect)]
         let peers = book.peers().collect::<Vec<_>>();
         assert!(peers.is_empty());
     }


### PR DESCRIPTION
Currently, the StorageService implements Clone, but the Drop impl will immediately signal the gc task to finish. So as soon as you create a single short lived clone of the StorageService and drop it, the gc task is gone.

This does the usual pattern of having an XXXInner and having the Drop on the inner. The outer is just an arc wrapper now.