### PR TITLE
Remove `uses sled` from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,9 +263,7 @@ where
 
 ## Efficient block storage implementation - ipfs-embed internals
 
-Ipfs embed uses sled to implement the block store. Sled is a rust embedded key value store,
-exposing an api that implements persistent lock free `BTreeMap` with support for transactions
-involving multiple trees.
+Ipfs embed uses SQLite to implement the block store, which is a performant embeddable SQL persistence layer / database.
 
 ```rust
 type Id = u64;


### PR DESCRIPTION
The readme shows some dates information, namely that `sled` is used for storage. Most people won't really care for this, but for me this was a particular advantage as I'd like to embed this library into a project that already uses sled.

I haven't removed `sled` from line 240 - I don't know how that should change.