### PR TITLE
Make it possible to run Bitswap in go-ipfs compatible mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ default = ["async_global"]
 async_global = ["async-global-executor", "libp2p/tcp-async-io", "libp2p/dns-async-std"]
 tokio = ["tokio-crate", "libp2p/tcp-tokio", "libp2p/dns-tokio"]
 telemetry = ["tide", "async_global"]
+# Makes it possible to exchange data via Bitswap with a go-ipfs node
+compat = ["libp2p-bitswap/compat"]
 
 [dependencies]
 anyhow = "1.0.41"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ applications.
 * temporary recursive pins for building dags, preventing races with the garbage collector
 * efficiently syncing large dags of blocks
 
-It does *not* aim at being compatible in any way with `go-ipfs`.
 Some compatibility with go-ipfs can be enabled with the `compat` feature flag.
 
 ## Getting started

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ applications.
 * efficiently syncing large dags of blocks
 
 It does *not* aim at being compatible in any way with `go-ipfs`.
+Some compatibility with go-ipfs can be enabled with the `compat` feature flag.
 
 ## Getting started
 ```rust


### PR DESCRIPTION
When setting the `compat` feature flag, ipfs-embed will also negotiate
the `/ipfs/bitswap` protocol with the node it connects to. This makes
it possible to exchange data with a go-ipfs node.