### PR TITLE
log gc failures

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -169,6 +169,10 @@ where
                         tracing::trace!("gc_loop running incremental gc");
                         gc.lock()
                             .incremental_gc(gc_min_blocks, gc_target_duration)
+                            .map_err(|e| {
+                                tracing::warn!("failure during incremental gc: {}", e);
+                                e
+                            })
                             .ok();
                         phase = Phase::Delete;
                     }
@@ -176,6 +180,10 @@ where
                         tracing::trace!("gc_loop running incremental delete orphaned");
                         gc.lock()
                             .incremental_delete_orphaned(gc_min_blocks, gc_target_duration)
+                            .map_err(|e| {
+                                tracing::warn!("failure during delete_orphaned: {}", e);
+                                e
+                            })
                             .ok();
                         phase = Phase::Gc;
                     }

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -153,11 +153,13 @@ impl<P: StoreParams> NetworkService<P> {
         let swarm_task = executor.spawn(future::poll_fn(move |cx| {
             waker.register(cx.waker());
             let mut guard = swarm.lock();
-            while {
+            loop {
                 let swarm = &mut *guard;
                 pin_mut!(swarm);
-                swarm.poll_next(cx).is_ready()
-            } {}
+                if !swarm.poll_next(cx).is_ready() {
+                    break;
+                }
+            }
             Poll::Pending
         }));
 


### PR DESCRIPTION
Currently failures are simply swallowed, so I don’t know why e.g. `incremental_delete_orphaned` fails.
